### PR TITLE
Logs command and node fixes

### DIFF
--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -12,12 +12,14 @@ import (
 )
 
 var (
-	flagDatadir      string
-	flagNetwork      string
-	flagDelete       bool
-	flagAttachLiquid bool
-	flagEnv          string
-	defaultPorts     = map[string]map[string]int{
+	flagDatadir       string
+	flagNetwork       string
+	flagDelete        bool
+	flagAttachLiquid  bool
+	flagLiquidService bool
+	flagEnv           string
+
+	defaultPorts = map[string]map[string]int{
 		"bitcoin": {
 			"node":        18443,
 			"electrs_rpc": 60401,
@@ -49,9 +51,11 @@ func init() {
 	StartCmd.PersistentFlags().BoolVar(&flagAttachLiquid, "liquid", false, "Enable liquid sidechain")
 	StartCmd.PersistentFlags().StringVar(&flagEnv, "ports", string(ports), "Set services ports in JSON format")
 	StopCmd.PersistentFlags().BoolVar(&flagDelete, "delete", false, "Stop and delete nigiri")
+	LogsCmd.PersistentFlags().BoolVar(&flagLiquidService, "liquid", false, "Set to see logs of a liquid service")
 
 	RootCmd.AddCommand(StartCmd)
 	RootCmd.AddCommand(StopCmd)
+	RootCmd.AddCommand(LogsCmd)
 
 	viper := config.Viper()
 	viper.BindPFlag(config.Datadir, RootCmd.PersistentFlags().Lookup("datadir"))

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/vulpemventures/nigiri/cli/config"
+	"github.com/altafan/nigiri/cli/config"
 	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/altafan/nigiri/cli/config"
+	"github.com/vulpemventures/nigiri/cli/config"
 	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+
+	"github.com/altafan/nigiri/cli/config"
+
+	"github.com/spf13/cobra"
+)
+
+var LogsCmd = &cobra.Command{
+	Use:     "logs",
+	Short:   "Check service logs",
+	RunE:    logs,
+	PreRunE: logsChecks,
+}
+
+var services = map[string]bool{
+	"node":       true,
+	"electrs":    true,
+	"esplora":    true,
+	"chopsticks": true,
+}
+
+func logsChecks(cmd *cobra.Command, args []string) error {
+	datadir, _ := cmd.Flags().GetString("datadir")
+	isLiquidService, _ := cmd.Flags().GetBool("liquid")
+
+	if !isDatadirOk(datadir) {
+		return fmt.Errorf("Invalid datadir, it must be an absolute path: %s", datadir)
+	}
+	if len(args) != 1 {
+		return fmt.Errorf("Invalid number of args, expected 1, got: %d", len(args))
+	}
+
+	service := args[0]
+	if !services[service] {
+		return fmt.Errorf("Invalid service, must be one of %s. Got: %s", reflect.ValueOf(services).MapKeys(), service)
+	}
+	isRunning, err := nigiriIsRunning()
+	if err != nil {
+		return err
+	}
+	if !isRunning {
+		return fmt.Errorf("Nigiri is not running")
+	}
+
+	if err := config.ReadFromFile(datadir); err != nil {
+		return err
+	}
+
+	if isLiquidService && isLiquidService != config.GetBool(config.AttachLiquid) {
+		return fmt.Errorf("Nigiri has been started with no Liquid sidechain.\nPlease stop and restart it using the --liquid flag")
+	}
+
+	return nil
+}
+
+func logs(cmd *cobra.Command, args []string) error {
+	service := args[0]
+	datadir, _ := cmd.Flags().GetString("datadir")
+	isLiquidService, _ := cmd.Flags().GetBool("liquid")
+
+	serviceName := getServiceName(service, isLiquidService)
+	composePath := getPath(datadir, "compose")
+	envPath := getPath(datadir, "env")
+	env := loadEnv(envPath)
+
+	bashCmd := exec.Command("docker-compose", "-f", composePath, "logs", serviceName)
+	bashCmd.Stdout = os.Stdout
+	bashCmd.Stderr = os.Stderr
+	bashCmd.Env = env
+
+	if err := bashCmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getServiceName(name string, liquid bool) string {
+	service := name
+	if service == "node" {
+		service = "bitcoin"
+	}
+	if liquid {
+		if service == "node" {
+			service = "liquid"
+		} else {
+			service = fmt.Sprintf("%s-liquid", service)
+		}
+	}
+
+	return service
+}

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"reflect"
 
-	"github.com/altafan/nigiri/cli/config"
+	"github.com/vulpemventures/nigiri/cli/config"
 
 	"github.com/spf13/cobra"
 )

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -15,7 +15,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
-	"github.com/vulpemventures/nigiri/cli/config"
+	"github.com/altafan/nigiri/cli/config"
 )
 
 const listAll = true

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -12,10 +12,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/altafan/nigiri/cli/config"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
-	"github.com/altafan/nigiri/cli/config"
 )
 
 const listAll = true
@@ -93,6 +93,7 @@ func startChecks(cmd *cobra.Command, args []string) error {
 
 func start(cmd *cobra.Command, args []string) error {
 	datadir, _ := cmd.Flags().GetString("datadir")
+	liquidEnabled, _ := cmd.Flags().GetBool("liquid")
 
 	bashCmd, err := getStartBashCmd(datadir)
 	if err != nil {
@@ -109,11 +110,19 @@ func start(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	for chain, services := range ports {
+	prettyPrintServices := func(chain string, services map[string]int) {
 		fmt.Printf("%s services:\n", chain)
 		for name, port := range services {
 			formatName := fmt.Sprintf("%s:", name)
 			fmt.Printf("   %-14s localhost:%d\n", formatName, port)
+		}
+	}
+
+	for chain, services := range ports {
+		if chain == "bitcoin" {
+			prettyPrintServices(chain, services)
+		} else if liquidEnabled {
+			prettyPrintServices(chain, services)
 		}
 	}
 

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/altafan/nigiri/cli/config"
+	"github.com/vulpemventures/nigiri/cli/config"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/vulpemventures/nigiri/cli/config"
+	"github.com/altafan/nigiri/cli/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -70,9 +70,9 @@ func stop(cmd *cobra.Command, args []string) error {
 		if err := os.Remove(envFile); err != nil {
 			return err
 		}
-	}
 
-	fmt.Println("Nigiri has been cleaned up successfully.")
+		fmt.Println("Nigiri has been cleaned up successfully.")
+	}
 
 	return nil
 }

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/altafan/nigiri/cli/config"
+	"github.com/vulpemventures/nigiri/cli/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/vulpemventures/nigiri/cli/cmd"
+import "github.com/altafan/nigiri/cli/cmd"
 
 func main() {
 	cmd.RootCmd.Execute()

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/altafan/nigiri/cli/cmd"
+import "github.com/vulpemventures/nigiri/cli/cmd"
 
 func main() {
 	cmd.RootCmd.Execute()

--- a/resources/volumes/liquidregtest/config/bitcoin.conf
+++ b/resources/volumes/liquidregtest/config/bitcoin.conf
@@ -13,3 +13,4 @@ txindex=0
 rpcuser=admin1
 rpcpassword=123
 rpcallowip=0.0.0.0/0
+rpcbind=0.0.0.0

--- a/resources/volumes/liquidregtest/liquid-config/liquid.conf
+++ b/resources/volumes/liquidregtest/liquid-config/liquid.conf
@@ -7,6 +7,7 @@ rpcport=18884
 rpcuser=admin1
 rpcpassword=123
 rpcallowip=0.0.0.0/0
+rpcbind=0.0.0.0
 
 mainchainrpcport=19001
 mainchainrpchost=10.10.0.10

--- a/resources/volumes/regtest/config/bitcoin.conf
+++ b/resources/volumes/regtest/config/bitcoin.conf
@@ -13,3 +13,4 @@ txindex=0
 rpcuser=admin1
 rpcpassword=123
 rpcallowip=0.0.0.0/0
+rpcbind=0.0.0.0


### PR DESCRIPTION
Our `vulpemventures/bitcoin` image is based on Ubuntu, this is known. It seems that the `bitcoind` version has been updated on the package manager registry.
The bitcoind v0.18 is the cause of 2 problems:
  1) bitcoin container is not reachable neather from other containers, nor from the host machine
  2) chopsticks fails to mine 101 blocks on regtest because bitcoind is not reachable and because  `generate` has been deprecated and now returns error. 

The solution to 1) is #41 . For 2) a [PR](https://github.com/vulpemventures/nigiri-chopsticks/pull/14) has already been opened.

This closes #41 and closes #40 and closes #33.

NOTE: paths must be changed before merging
