### PR TITLE
Use linking instead of ip addresses to link services in docker compose.

### DIFF
--- a/resources/docker-compose-regtest-liquid.yml
+++ b/resources/docker-compose-regtest-liquid.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 services:
   # RPC daemons
   bitcoin:
@@ -144,3 +144,6 @@ services:
     ports:
       - ${LIQUID_CHOPSTICKS_PORT}:3000
     restart: unless-stopped
+networks:
+  default:
+    name: nigiri

--- a/resources/docker-compose-regtest-liquid.yml
+++ b/resources/docker-compose-regtest-liquid.yml
@@ -4,9 +4,6 @@ services:
   bitcoin:
     image: vulpemventures/bitcoin:latest
     container_name: bitcoin
-    networks:
-      local:
-        ipv4_address: 10.10.0.10
     ports:
       - ${BITCOIN_PEER_PORT}:19000
       - ${BITCOIN_NODE_PORT}:19001
@@ -18,9 +15,6 @@ services:
     container_name: liquid
     command:
       - -datadir=config
-    networks:
-      local:
-        ipv4_address: 10.10.0.11
     ports:
       - ${LIQUID_NODE_PORT}:18884
       - ${LIQUID_PEER_PORT}:18886
@@ -40,7 +34,7 @@ services:
       - --daemon-dir
       - /config
       - --daemon-rpc-addr
-      - 10.10.0.10:19001
+      - bitcoin:19001
       - --cookie
       - admin1:123
       - --http-addr
@@ -49,9 +43,6 @@ services:
       - 0.0.0.0:60401
       - --cors
       - "*"
-    networks:
-      local:
-        ipv4_address: 10.10.0.12
     depends_on:
       - bitcoin
     ports:
@@ -74,7 +65,7 @@ services:
       - --daemon-dir
       - /config
       - --daemon-rpc-addr
-      - 10.10.0.11:18884
+      - liquid:18884
       - --cookie
       - admin1:123
       - --http-addr
@@ -83,9 +74,6 @@ services:
       - 0.0.0.0:60401
       - --cors
       - "*"
-    networks:
-      local:
-        ipv4_address: 10.10.0.13
     depends_on:
       - liquid
     ports:
@@ -98,9 +86,6 @@ services:
   esplora:
     image: vulpemventures/esplora:latest
     container_name: esplora
-    networks:
-      local:
-        ipv4_address: 10.10.0.14
     depends_on:
       - chopsticks
     environment:
@@ -111,9 +96,6 @@ services:
   esplora-liquid:
     image: vulpemventures/esplora:latest
     container_name: esplora-liquid
-    networks:
-      local:
-        ipv4_address: 10.10.0.15
     depends_on:
       - chopsticks-liquid
     environment:
@@ -130,9 +112,9 @@ services:
       - --use-mining
       - --use-logger
       - --rpc-addr
-      - 10.10.0.10:19001
+      - bitcoin:19001
       - --electrs-addr
-      - 10.10.0.12:3002
+      - electrs:3002
       - --addr
       - 0.0.0.0:3000
     depends_on:
@@ -140,9 +122,6 @@ services:
       - electrs
     ports:
       - ${BITCOIN_CHOPSTICKS_PORT}:3000
-    networks:
-      local:
-        ipv4_address: 10.10.0.16
     restart: unless-stopped
   chopsticks-liquid:
     image: vulpemventures/nigiri-chopsticks:latest
@@ -152,9 +131,9 @@ services:
       - --use-mining
       - --use-logger
       - --rpc-addr
-      - 10.10.0.11:18884
+      - liquid:18884
       - --electrs-addr
-      - 10.10.0.13:3002
+      - electrs-liquid:3002
       - --addr
       - 0.0.0.0:3000
       - --chain
@@ -164,14 +143,4 @@ services:
       - electrs-liquid
     ports:
       - ${LIQUID_CHOPSTICKS_PORT}:3000
-    networks:
-      local:
-        ipv4_address: 10.10.0.17
     restart: unless-stopped
-
-networks:
-  local:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 10.10.0.0/24

--- a/resources/docker-compose-regtest.yml
+++ b/resources/docker-compose-regtest.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 services:
   # RPC daemon
   bitcoin:
@@ -71,3 +71,6 @@ services:
     ports:
       - ${BITCOIN_CHOPSTICKS_PORT}:3000
     restart: unless-stopped
+networks:
+  default:
+    name: nigiri

--- a/resources/docker-compose-regtest.yml
+++ b/resources/docker-compose-regtest.yml
@@ -4,9 +4,6 @@ services:
   bitcoin:
     image: vulpemventures/bitcoin:latest
     container_name: bitcoin
-    networks:
-      local:
-        ipv4_address: 10.10.0.10
     ports:
       - ${BITCOIN_PEER_PORT}:19000
       - ${BITCOIN_NODE_PORT}:19001
@@ -26,7 +23,7 @@ services:
       - --daemon-dir
       - /config
       - --daemon-rpc-addr
-      - 10.10.0.10:19001
+      - bitcoin:19001
       - --cookie
       - admin1:123
       - --http-addr
@@ -35,9 +32,6 @@ services:
       - 0.0.0.0:60401
       - --cors
       - "*"
-    networks:
-      local:
-        ipv4_address: 10.10.0.11
     depends_on:
       - bitcoin
     ports:
@@ -50,9 +44,6 @@ services:
   esplora:
     image: vulpemventures/esplora:latest
     container_name: esplora
-    networks:
-      local:
-        ipv4_address: 10.10.0.12
     depends_on:
       - chopsticks
     environment:
@@ -69,24 +60,14 @@ services:
       - --use-mining
       - --use-logger
       - --rpc-addr
-      - 10.10.0.10:19001
+      - bitcoin:19001
       - --electrs-addr
-      - 10.10.0.11:3002
+      - electrs:3002
       - --addr
       - 0.0.0.0:3000
-    networks:
-      local:
-        ipv4_address: 10.10.0.13
     depends_on:
       - bitcoin
       - electrs
     ports:
       - ${BITCOIN_CHOPSTICKS_PORT}:3000
     restart: unless-stopped
-
-networks:
-  local:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 10.10.0.0/24


### PR DESCRIPTION
By default, in docker compose, any service can reach any other service at that service’s name.

Note: I was not able to run `make test`. It seems to get stuck on my machine. 
Anyway, I compiled and tested it locally and it seems to work. 