### PR TITLE
add compact filters flags + pchmessagestart in elements.conf

### DIFF
--- a/cmd/nigiri/resources/elements.conf
+++ b/cmd/nigiri/resources/elements.conf
@@ -9,6 +9,9 @@ rpcuser=admin1
 rpcpassword=123
 rpcallowip=0.0.0.0/0
 rpcbind=0.0.0.0
+pchmessagestart=12345678
+blockfilterindex=1
+peerblockfilters=1
 
 mainchainrpcport=18443
 mainchainrpcuser=admin1


### PR DESCRIPTION
- add the COMPACT_FILTERS service to elements instance.
- the magic bytes of the nigiri network are now a constant `0x12345678`.

@tiero please review