### PR TITLE
Enable ‘Neutrino mode’ in Bitcoin Core by default

### DIFF
--- a/cmd/nigiri/resources/bitcoin.conf
+++ b/cmd/nigiri/resources/bitcoin.conf
@@ -18,3 +18,6 @@ fallbackfee=0.00001
 
 zmqpubrawblock=tcp://0.0.0.0:28332
 zmqpubrawtx=tcp://0.0.0.0:28333
+
+blockfilterindex=1
+peerblockfilters=1


### PR DESCRIPTION
To encourage more use of Nigiri for developers working on Bitcoin light clients such as [LND](https://github.com/lightningnetwork/lnd) running in Neutrino mode, turning on `blockfilterindex` and `peerblockfilters` by default will make it easier to work with.

See 
https://github.com/lightninglabs/docs.lightning.engineering/blob/master/lightning-network-tools/lnd/enable-neutrino-mode-in-bitcoin-core.md for more information.