### PR TITLE
⚡️⚡️⚡️ Lightning Network support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,40 +41,164 @@ $ nigiri start --liquid
 ```
 **That's it.**
 
----
-**Note for users of macOS Monterey**
-
-When trying to start Nigiri, you might get an error similar to the following:
-
-```
-Error response from daemon: Ports are not available: listen tcp 0.0.0.0:5000: bind: address already in use
-exit status 1
-```
-
-This is due to AirPlay Receiver using port 5000, conflicting with Esplora trying to run using the very same port. 
-
-There are two ways to deal with this issue:
-
-1) Uncheck AirPlay Receiver in `System Preferences → Sharing → AirPlay Receiver`
-2) Change Esplora’s port to something other than 5000. This can be done by changing it in [docker-compose.yml](https://github.com/vulpemventures/nigiri/blob/master/cmd/nigiri/resources/docker-compose.yml#L110) found in your data directory. If you previously tried starting Nigiri getting an error – you might have to run `nigiri stop --delete`  before restarting it.
-
----
-
 Go to http://localhost:5000 for quickly inspect the Bitcoin blockchain or http://localhost:5001 for Liquid.
 
-* Use the Bitcoin CLI inside the box
 
+**Note for users of macOS Monterey an onward**
+<details>
+  <summary>Show more...</summary>
+    When trying to start Nigiri, you might get an error similar to the following:
+
+    ```
+    Error response from daemon: Ports are not available: listen tcp 0.0.0.0:5000: bind: address already in use
+    exit status 1
+    ```
+
+    This is due to AirPlay Receiver using port 5000, conflicting with Esplora trying to run using the very same port. 
+
+    There are two ways to deal with this issue:
+
+    1) Uncheck AirPlay Receiver in `System Preferences → Sharing → AirPlay Receiver`
+    2) Change Esplora’s port to something other than 5000. This can be done by changing it in [docker-compose.yml](https://github.com/vulpemventures/nigiri/blob/master/cmd/nigiri/resources/docker-compose.yml#L110) found in your data directory. If you previously tried starting Nigiri getting an error – you might have to run `nigiri stop --delete`  before restarting it.
+</details>
+<br />
+
+## Tasting
+
+At the moment bitcoind, elements and electrs are started on *regtest* network.
+
+
+### Start nigiri
+
+```bash
+$ nigiri start
 ```
+- Use the `--liquid` flag to let you do experiments with the Liquid sidechain. A liquid daemon and a block explorer are also started when passing this flag.
+
+- Use the `--ln` flag to start a Core Lightning node and a LND node.
+
+### Stop nigiri
+
+```bash
+$ nigiri stop
+```
+Use the `--delete` flag to not just stop Docker containers but also to remove them and delete the config file and any new data written in volumes.
+
+### Generate and send bitcoin to given address
+
+```bash
+# Bitcoin
+$ nigiri faucet <bitcoin_address>
+## Fund the Core Lightning node
+$ nigiri faucet cln 0.01
+
+## Fund the LND node
+$ nigiri faucet lnd 0.01
+
+# Elements
+$ nigiri faucet --liquid <liquid_address>
+```
+
+### **Liquid only** Issue and send a given quantity of an asset
+
+```bash
+$ nigiri mint <liquid_address> 1000 VulpemToken VLP
+```
+
+### Broadcast a raw transaction and automatically generate a block
+
+```bash
+# Bitcoin
+$ nigiri push <hex>
+
+# Elements
+$ nigiri push --liquid <hex>
+```
+
+### Check the logs of Bitcoin services
+
+```bash
+# Bitcoind
+$ nigiri logs bitcoin
+# Electrs
+$ nigiri logs electrs
+# Chopsticks
+$ nigiri logs chopsticks
+```
+
+### Check the logs of Liquid services
+
+```bash
+# Elementsd
+$ nigiri logs liquid
+# Electrs Liquid
+$ nigiri logs electrs-liquid
+# Chopsticks Liquid
+$ nigiri logs chopsticks-liquid
+```
+
+### Check the logs of Lightning services
+
+```bash
+# Core Lightning
+$ nigiri logs cln
+# LND
+$ nigiri logs lnd
+```
+
+### Use the Bitcoin CLI inside the box
+
+```bash
 $ nigiri rpc getnewaddress "" "bech32"
 bcrt1qsl4j5je4gu3ecjle8lckl3u8yywh8rff6xxk2r
 ```
 
-* Use the Elements CLI inside the box
+### Use the Elements CLI inside the box
 
-```
+```bash
 $ nigiri rpc --liquid getnewaddress "" "bech32"
 el1qqwwx9gyrcrjrhgnrnjq9dq9t4hykmr6ela46ej63dnkdkcg8veadrvg5p0xg0zd6j3aug74cv9m4cf4jslwdqnha2w2nsg9x3
 ```
+
+### Use the Core Lightning & LND CLIs inside the box
+
+```bash
+# Core Lightning
+$ nigiri cln listpeers
+# LND
+$ nigiri lnd listpeers
+```
+
+### Connect Core Lightning to LND
+
+```bash
+$ nigiri cln connect `nigiri lnd getinfo | jq -r .identity_pubkey`@lnd:9735
+```
+
+### Open a channel between cln and lnd
+
+```bash
+$ nigiri lnd openchannel --node_key=`nigiri cln getinfo | jq -r .id` --local_amt=100000
+```
+
+
+### Run in headless mode (without Esplora)
+If you are looking to spin-up Nigiri in Travis or Github Action you can use the `--ci` flag.
+
+```
+$ nigiri start --ci [--liquid] [--ln]
+```
+
+### Update the docker images
+
+```
+$ nigiri update
+```
+
+Nigiri uses the default directory `~/.nigiri` to store configuration files and docker-compose files.
+To set a custom directory use the `--datadir` flag.
+
+Run the `help` command to see the full list of available flags.
 
 # Make from scratch
 ## Utensils
@@ -124,111 +248,6 @@ Remeber to always `clean` Nigiri before running `install` to upgrade to a new ve
 ```
 $ make clean
 ```
-
-
-
-## Tasting
-
-At the moment bitcoind, elements and electrs are started on *regtest* network.
-
-
-*  Start nigiri:
-
-```bash
-$ nigiri start
-```
-Use the `--liquid` flag to let you do experiments with the Liquid sidechain. A liquid daemon and a block explorer are also started when passing this flag.
-
-* Stop nigiri:
-
-```bash
-$ nigiri stop
-```
-Use the `--delete` flag to not just stop Docker containers but also to remove them and delete the config file and any new data written in volumes.
-
-* Generate and send bitcoin to given address
-
-```bash
-# Bitcoin
-$ nigiri faucet bcrt1qsl4j5je4gu3ecjle8lckl3u8yywh8rff6xxk2r
-
-# Elements
-$ nigiri faucet --liquid el1qqwwx9gyrcrjrhgnrnjq9dq9t4hykmr6ela46ej63dnkdkcg8veadrvg5p0xg0zd6j3aug74cv9m4cf4jslwdqnha2w2nsg9x3
-```
-
-* Liquid only Issue and send a given quantity of an asset
-
-```bash
-$ nigiri mint el1qqwwx9gyrcrjrhgnrnjq9dq9t4hykmr6ela46ej63dnkdkcg8veadrvg5p0xg0zd6j3aug74cv9m4cf4jslwdqnha2w2nsg9x3 1000 VulpemToken VLP
-```
-
-* Broadcast a raw transaction and automatically generate a block
-
-```bash
-# Bitcoin
-$ nigiri push <hex>
-
-# Elements
-$ nigiri push --liquid <hex>
-```
-
-* Check the logs of Bitcoin services
-
-```bash
-# Bitcoind
-$ nigiri logs bitcoin
-# Electrs
-$ nigiri logs electrs
-# Chopsticks
-$ nigiri logs chopsticks
-```
-
-* Check the logs of Liquid services
-
-```bash
-# Elementsd
-$ nigiri logs liquid
-# Electrs Liquid
-$ nigiri logs electrs-liquid
-# Chopsticks Liquid
-$ nigiri logs chopsticks-liquid
-```
-
-* Use the Bitcoin CLI inside the box
-
-```
-$ nigiri rpc getnewaddress "" "bech32"
-bcrt1qsl4j5je4gu3ecjle8lckl3u8yywh8rff6xxk2r
-```
-
-* Use the Elements CLI inside the box
-
-```
-$ nigiri rpc --liquid getnewaddress "" "bech32"
-el1qqwwx9gyrcrjrhgnrnjq9dq9t4hykmr6ela46ej63dnkdkcg8veadrvg5p0xg0zd6j3aug74cv9m4cf4jslwdqnha2w2nsg9x3
-```
-
-* Run in headless mode (without Esplora)
-If you are looking to spin-up Nigiri in Travis or Github Action you can use the `--ci` flag.
-
-```
-$ nigiri start --ci [--liquid]
-```
-
-
-* Update the docker images
-
-```
-$ nigiri update
-```
-
-
-
-
-Nigiri uses the default directory `~/.nigiri` to store configuration files and docker-compose files.
-To set a custom directory use the `--datadir` flag.
-
-Run the `help` command to see the full list of available flags.
 
 ## Nutrition Facts
 

--- a/README.md
+++ b/README.md
@@ -47,19 +47,18 @@ Go to http://localhost:5000 for quickly inspect the Bitcoin blockchain or http:/
 **Note for users of macOS Monterey an onward**
 <details>
   <summary>Show more...</summary>
-    When trying to start Nigiri, you might get an error similar to the following:
+   When trying to start Nigiri, you might get an error similar to the following:
 
-    ```
-    Error response from daemon: Ports are not available: listen tcp 0.0.0.0:5000: bind: address already in use
-    exit status 1
-    ```
+  ```bash
+  Error response from daemon: Ports are not available: listen tcp 0.0.0.0:5000: bind: address already in use 
+  exit status 1
+  ```
+  This is due to AirPlay Receiver using port 5000, conflicting with Esplora trying to run using the very same port. 
 
-    This is due to AirPlay Receiver using port 5000, conflicting with Esplora trying to run using the very same port. 
+  There are two ways to deal with this issue:
 
-    There are two ways to deal with this issue:
-
-    1) Uncheck AirPlay Receiver in `System Preferences → Sharing → AirPlay Receiver`
-    2) Change Esplora’s port to something other than 5000. This can be done by changing it in [docker-compose.yml](https://github.com/vulpemventures/nigiri/blob/master/cmd/nigiri/resources/docker-compose.yml#L110) found in your data directory. If you previously tried starting Nigiri getting an error – you might have to run `nigiri stop --delete`  before restarting it.
+  1) Uncheck AirPlay Receiver in `System Preferences → Sharing → AirPlay Receiver`
+  2) Change Esplora’s port to something other than 5000. This can be done by changing it in [docker-compose.yml](https://github.com/vulpemventures/nigiri/blob/master/cmd/nigiri/resources/docker-compose.yml#L110) found in your data directory. If you previously tried starting Nigiri getting an error – you might have to run `nigiri stop --delete`  before restarting it.
 </details>
 <br />
 

--- a/cmd/nigiri/cln.go
+++ b/cmd/nigiri/cln.go
@@ -25,9 +25,10 @@ func clnAction(ctx *cli.Context) error {
 		return err
 	}
 
-	rpcArgs := []string{"exec", "cln", "lightning-cli", "--network=" + network}
+	rpcArgs := []string{"exec", "-it", "cln", "lightning-cli", "--network=" + network}
 	cmdArgs := append(rpcArgs, ctx.Args().Slice()...)
 	bashCmd := exec.Command("docker", cmdArgs...)
+	bashCmd.Stdin = os.Stdin
 	bashCmd.Stdout = os.Stdout
 	bashCmd.Stderr = os.Stderr
 

--- a/cmd/nigiri/cln.go
+++ b/cmd/nigiri/cln.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+
+	"github.com/urfave/cli/v2"
+)
+
+var cln = cli.Command{
+	Name:   "cln",
+	Usage:  "invoke Core Lightning command line",
+	Action: clnAction,
+}
+
+func clnAction(ctx *cli.Context) error {
+
+	if isRunning, _ := nigiriState.GetBool("running"); !isRunning {
+		return errors.New("nigiri is not running")
+	}
+
+	network, err := nigiriState.GetString("network")
+	if err != nil {
+		return err
+	}
+
+	rpcArgs := []string{"exec", "cln", "lightning-cli", "--network=" + network}
+	cmdArgs := append(rpcArgs, ctx.Args().Slice()...)
+	bashCmd := exec.Command("docker", cmdArgs...)
+	bashCmd.Stdout = os.Stdout
+	bashCmd.Stderr = os.Stderr
+
+	if err := bashCmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/nigiri/faucet.go
+++ b/cmd/nigiri/faucet.go
@@ -57,9 +57,8 @@ func faucetAction(ctx *cli.Context) error {
 		return err
 	}
 
-	var address string
-	firstArgument := ctx.Args().First()
-	if firstArgument == "cln" {
+	address := ctx.Args().First()
+	if address == "cln" {
 		jsonOut, err := outputCommand("docker", "exec", "cln", "lightning-cli", "--network="+network, "newaddr")
 		if err != nil {
 			return err
@@ -71,7 +70,7 @@ func faucetAction(ctx *cli.Context) error {
 		}
 	}
 
-	if firstArgument == "lnd" {
+	if address == "lnd" {
 		jsonOut, err := outputCommand("docker", "exec", "lnd", "lncli", "--network="+network, "newaddress", "p2wkh")
 		if err != nil {
 			return err

--- a/cmd/nigiri/lnd.go
+++ b/cmd/nigiri/lnd.go
@@ -25,9 +25,10 @@ func lndAction(ctx *cli.Context) error {
 		return err
 	}
 
-	rpcArgs := []string{"exec", "lnd", "lncli", "--network=" + network}
+	rpcArgs := []string{"exec", "-it", "lnd", "lncli", "--network=" + network}
 	cmdArgs := append(rpcArgs, ctx.Args().Slice()...)
 	bashCmd := exec.Command("docker", cmdArgs...)
+	bashCmd.Stdin = os.Stdin
 	bashCmd.Stdout = os.Stdout
 	bashCmd.Stderr = os.Stderr
 

--- a/cmd/nigiri/lnd.go
+++ b/cmd/nigiri/lnd.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+
+	"github.com/urfave/cli/v2"
+)
+
+var lnd = cli.Command{
+	Name:   "lnd",
+	Usage:  "invoke LND command line",
+	Action: lndAction,
+}
+
+func lndAction(ctx *cli.Context) error {
+
+	if isRunning, _ := nigiriState.GetBool("running"); !isRunning {
+		return errors.New("nigiri is not running")
+	}
+
+	network, err := nigiriState.GetString("network")
+	if err != nil {
+		return err
+	}
+
+	rpcArgs := []string{"exec", "lnd", "lncli", "--network=" + network}
+	cmdArgs := append(rpcArgs, ctx.Args().Slice()...)
+	bashCmd := exec.Command("docker", cmdArgs...)
+	bashCmd.Stdout = os.Stdout
+	bashCmd.Stderr = os.Stderr
+
+	if err := bashCmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/nigiri/main.go
+++ b/cmd/nigiri/main.go
@@ -45,7 +45,6 @@ var datadirFlag = cli.StringFlag{
 //go:embed resources/bitcoin.conf
 //go:embed resources/elements.conf
 //go:embed resources/lnd.conf
-//go:embed resources/lightning.conf
 var f embed.FS
 
 func main() {
@@ -117,7 +116,7 @@ func provisionResourcesToDatadir(datadir string) error {
 	if err := makeDirectoryIfNotExists(filepath.Join(datadir, "volumes", "lnd")); err != nil {
 		return err
 	}
-	if err := makeDirectoryIfNotExists(filepath.Join(datadir, "volumes", "lnd2")); err != nil {
+	if err := makeDirectoryIfNotExists(filepath.Join(datadir, "volumes", "lightningd")); err != nil {
 		return err
 	}
 
@@ -152,22 +151,6 @@ func provisionResourcesToDatadir(datadir string) error {
 	); err != nil {
 		return err
 	}
-
-	// copy second lnd.conf into the Nigiri data directory
-	if err := copyFromResourcesToDatadir(
-		filepath.Join("resources", "lnd.conf"),
-		filepath.Join(datadir, "volumes", "lnd2", "lnd.conf"),
-	); err != nil {
-		return err
-	}
-
-	/* 	// copy lightning.conf into the Nigiri data directory
-	   	if err := copyFromResourcesToDatadir(
-	   		filepath.Join("resources", "lightning.conf"),
-	   		filepath.Join(datadir, "volumes", "lightningd", "lightning.conf"),
-	   	); err != nil {
-	   		return err
-	   	} */
 
 	if err := nigiriState.Set(map[string]string{"ready": strconv.FormatBool(true)}); err != nil {
 		return err

--- a/cmd/nigiri/main.go
+++ b/cmd/nigiri/main.go
@@ -57,6 +57,8 @@ func main() {
 	app.Commands = append(
 		app.Commands,
 		&rpc,
+		&lnd,
+		&cln,
 		&stop,
 		&logs,
 		&mint,

--- a/cmd/nigiri/main.go
+++ b/cmd/nigiri/main.go
@@ -29,6 +29,12 @@ var liquidFlag = cli.BoolFlag{
 	Value: false,
 }
 
+var lnFlag = cli.BoolFlag{
+	Name:  "ln",
+	Usage: "enable Lightning Network",
+	Value: false,
+}
+
 var datadirFlag = cli.StringFlag{
 	Name:  "datadir",
 	Usage: "use different data directory",
@@ -38,6 +44,8 @@ var datadirFlag = cli.StringFlag{
 //go:embed resources/docker-compose.yml
 //go:embed resources/bitcoin.conf
 //go:embed resources/elements.conf
+//go:embed resources/lnd.conf
+//go:embed resources/lightning.conf
 var f embed.FS
 
 func main() {
@@ -106,8 +114,14 @@ func provisionResourcesToDatadir(datadir string) error {
 	if err := makeDirectoryIfNotExists(filepath.Join(datadir, "volumes", "elements")); err != nil {
 		return err
 	}
+	if err := makeDirectoryIfNotExists(filepath.Join(datadir, "volumes", "lnd")); err != nil {
+		return err
+	}
+	if err := makeDirectoryIfNotExists(filepath.Join(datadir, "volumes", "lnd2")); err != nil {
+		return err
+	}
 
-	// copy resources into the Nigiri data directory
+	// copy docker compose into the Nigiri data directory
 	if err := copyFromResourcesToDatadir(
 		filepath.Join("resources", config.DefaultCompose),
 		filepath.Join(datadir, config.DefaultCompose),
@@ -115,6 +129,7 @@ func provisionResourcesToDatadir(datadir string) error {
 		return err
 	}
 
+	// copy bitcoin.conf into the Nigiri data directory
 	if err := copyFromResourcesToDatadir(
 		filepath.Join("resources", "bitcoin.conf"),
 		filepath.Join(datadir, "volumes", "bitcoin", "bitcoin.conf"),
@@ -122,12 +137,37 @@ func provisionResourcesToDatadir(datadir string) error {
 		return err
 	}
 
+	// copy elements.conf into the Nigiri data directory
 	if err := copyFromResourcesToDatadir(
 		filepath.Join("resources", "elements.conf"),
 		filepath.Join(datadir, "volumes", "elements", "elements.conf"),
 	); err != nil {
 		return err
 	}
+
+	// copy lnd.conf into the Nigiri data directory
+	if err := copyFromResourcesToDatadir(
+		filepath.Join("resources", "lnd.conf"),
+		filepath.Join(datadir, "volumes", "lnd", "lnd.conf"),
+	); err != nil {
+		return err
+	}
+
+	// copy second lnd.conf into the Nigiri data directory
+	if err := copyFromResourcesToDatadir(
+		filepath.Join("resources", "lnd.conf"),
+		filepath.Join(datadir, "volumes", "lnd2", "lnd.conf"),
+	); err != nil {
+		return err
+	}
+
+	/* 	// copy lightning.conf into the Nigiri data directory
+	   	if err := copyFromResourcesToDatadir(
+	   		filepath.Join("resources", "lightning.conf"),
+	   		filepath.Join(datadir, "volumes", "lightningd", "lightning.conf"),
+	   	); err != nil {
+	   		return err
+	   	} */
 
 	if err := nigiriState.Set(map[string]string{"ready": strconv.FormatBool(true)}); err != nil {
 		return err

--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.8'
 services:
 
   # RPC daemon
@@ -169,7 +169,7 @@ services:
     container_name: lnd
     image: lightninglabs/lnd:v0.14.3-beta
     user: 1000:1000
-    depends_on: 
+    depends_on:
       - bitcoin
     volumes:
       - ./volumes/lnd:/data/.lnd
@@ -181,21 +181,28 @@ services:
       - "9735:9735" # p2p
       - "10009:10009" # grpc
 
-  lnd2:
-    container_name: lnd2
-    image: lightninglabs/lnd:v0.14.3-beta
-    user: 1000:1000
-    depends_on: 
-      - bitcoin
-    volumes:
-      - ./volumes/lnd2:/data/.lnd
+  lightningd:
+    container_name: cln
+    image: elementsproject/lightningd:latest
     environment:
-      HOME: /data
-    restart: unless-stopped
-    stop_grace_period: 5m30s
+      LIGHTNINGD_PORT: 9935
+      EXPOSE_TCP: "true"
+    command: 
+      - --network=regtest 
+      - --alias=nigiri
+      - --bitcoin-rpcconnect=bitcoin:18443
+      - --bitcoin-rpcuser=admin1 
+      - --bitcoin-rpcpassword=123 
+      - --log-level=debug 
+    depends_on:
+      - bitcoin
     ports:
-      - "19735:9735" # p2p
-      - "20009:10009" # grpc
+      - 9935:9935 # p2p
+      - 9835:9835 # rpc
+    restart: unless-stopped
+    volumes:
+      - ./volumes/lightningd:/root/.lightning
+      - ./volumes/bitcoin:/etc/bitcoin
 
 networks:
   default:

--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3.7'
 services:
+
   # RPC daemon
   bitcoin:
     image: ghcr.io/vulpemventures/bitcoin:latest
@@ -16,7 +17,7 @@ services:
     volumes:
       - ./volumes/bitcoin/:/config
     restart: unless-stopped
-  
+
   liquid:
     image: ghcr.io/vulpemventures/elements:latest
     user: 1000:1000
@@ -104,8 +105,8 @@ services:
     container_name: esplora
     depends_on:
       - chopsticks
-    environment: 
-        API_URL: http://localhost:3000
+    environment:
+      API_URL: http://localhost:3000
     ports:
       - 5000:5000
     restart: unless-stopped
@@ -120,6 +121,7 @@ services:
     ports:
       - 5001:5000
     restart: unless-stopped
+
   # Chopsticks
   chopsticks:
     image: ghcr.io/vulpemventures/nigiri-chopsticks:latest
@@ -162,6 +164,38 @@ services:
     ports:
       - 3001:3000
     restart: unless-stopped
+
+  lnd:
+    container_name: lnd
+    image: lightninglabs/lnd:v0.14.3-beta
+    user: 1000:1000
+    depends_on: 
+      - bitcoin
+    volumes:
+      - ./volumes/lnd:/data/.lnd
+    environment:
+      HOME: /data
+    restart: unless-stopped
+    stop_grace_period: 5m30s
+    ports:
+      - "9735:9735" # p2p
+      - "10009:10009" # grpc
+
+  lnd2:
+    container_name: lnd2
+    image: lightninglabs/lnd:v0.14.3-beta
+    user: 1000:1000
+    depends_on: 
+      - bitcoin
+    volumes:
+      - ./volumes/lnd2:/data/.lnd
+    environment:
+      HOME: /data
+    restart: unless-stopped
+    stop_grace_period: 5m30s
+    ports:
+      - "19735:9735" # p2p
+      - "20009:10009" # grpc
 
 networks:
   default:

--- a/cmd/nigiri/resources/lightning.conf
+++ b/cmd/nigiri/resources/lightning.conf
@@ -1,0 +1,9 @@
+network=regtest
+alias=nigiri
+log-level=debug
+disable-plugin=bcli
+large-channels=1
+jrest-port=7000
+bitcoin-rpcurl=http://bitcoin:18443 
+bitcoin-rpcuser=admin1
+bitcoin-rpcpassword=123

--- a/cmd/nigiri/resources/lightning.conf
+++ b/cmd/nigiri/resources/lightning.conf
@@ -1,9 +1,0 @@
-network=regtest
-alias=nigiri
-log-level=debug
-disable-plugin=bcli
-large-channels=1
-jrest-port=7000
-bitcoin-rpcurl=http://bitcoin:18443 
-bitcoin-rpcuser=admin1
-bitcoin-rpcpassword=123

--- a/cmd/nigiri/resources/lnd.conf
+++ b/cmd/nigiri/resources/lnd.conf
@@ -1,0 +1,37 @@
+[Application Options]
+debuglevel=debug
+noseedbackup=1
+
+
+[Bitcoin]
+; If the Bitcoin chain should be active. Atm, only a single chain can be
+; active.
+bitcoin.active=true
+
+; Use Bitcoin's regression test network
+bitcoin.regtest=true
+
+; Use the bitcoind back-end
+bitcoin.node=bitcoind
+
+[Bitcoind]
+; The host that your local bitcoind daemon is listening on. By default, this
+; setting is assumed to be localhost with the default port for the current
+; network.
+bitcoind.rpchost=bitcoin:18443
+
+; Username for RPC connections to bitcoind. By default, lnd will attempt to
+; automatically obtain the credentials, so this likely won't need to be set
+; (other than for a remote bitcoind instance).
+bitcoind.rpcuser=admin1
+
+; Password for RPC connections to bitcoind. By default, lnd will attempt to
+; automatically obtain the credentials, so this likely won't need to be set
+; (other than for a remote bitcoind instance).
+bitcoind.rpcpass=123
+
+; ZMQ socket which sends rawblock and rawtx notifications from bitcoind. By
+; default, lnd will attempt to automatically obtain this information, so this
+; likely won't need to be set (other than for a remote bitcoind instance).
+bitcoind.zmqpubrawblock=tcp://bitcoin:28332
+bitcoind.zmqpubrawtx=tcp://bitcoin:28333

--- a/cmd/nigiri/rpc.go
+++ b/cmd/nigiri/rpc.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -19,6 +20,11 @@ var rpc = cli.Command{
 			Usage: "rpcwallet to be used for node JSONRPC commands",
 			Value: "",
 		},
+		&cli.IntFlag{
+			Name:  "generate",
+			Usage: "generate block",
+			Value: 0,
+		},
 	},
 }
 
@@ -30,10 +36,14 @@ func rpcAction(ctx *cli.Context) error {
 
 	isLiquid := ctx.Bool("liquid")
 	rpcWallet := ctx.String("rpcwallet")
+	generate := ctx.Int("generate")
 
 	rpcArgs := []string{"exec", "bitcoin", "bitcoin-cli", "-datadir=config", "-rpcwallet=" + rpcWallet}
 	if isLiquid {
 		rpcArgs = []string{"exec", "liquid", "elements-cli", "-datadir=config", "-rpcwallet=" + rpcWallet}
+	}
+	if generate > 0 {
+		rpcArgs = append(rpcArgs, "-generate="+fmt.Sprint(generate))
 	}
 	cmdArgs := append(rpcArgs, ctx.Args().Slice()...)
 	bashCmd := exec.Command("docker", cmdArgs...)

--- a/cmd/nigiri/start.go
+++ b/cmd/nigiri/start.go
@@ -51,8 +51,8 @@ func startAction(ctx *cli.Context) error {
 	if isLN {
 		// LND
 		servicesToRun = append(servicesToRun, "lnd")
-		// Second LND node
-		servicesToRun = append(servicesToRun, "lnd2")
+		// Core Lightning Network
+		servicesToRun = append(servicesToRun, "lightningd")
 	}
 
 	if isCI {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -93,6 +93,19 @@ func (s *State) GetBool(key string) (bool, error) {
 	return value, nil
 }
 
+func (s *State) GetString(key string) (string, error) {
+	stateData, err := s.Get()
+	if err != nil {
+		return "", err
+	}
+
+	if _, ok := stateData[key]; !ok {
+		return "", errors.New("config: missing key " + key)
+	}
+
+	return stateData[key], nil
+}
+
 func merge(maps ...map[string]string) map[string]string {
 	merge := make(map[string]string)
 	for _, m := range maps {


### PR DESCRIPTION
This adds support of a much requested feature: ⚡️ Lightning Network support in Nigiri﻿ 🎉

## How to test?

1. Go here and grab the binary for your os/arch combo
https://github.com/tiero/nigiri/releases/tag/v0.4.0-ln.0
2. `sudo chmod a+x nigiri-x-y`
3.  `rm -rf ~/Library/Application\ Support/Nigiri`
4. `alias nigiri="./nigiri-x-y"`
5. `nigiri start --ln`

```sh
# start LND and CLN at same time
nigiri start --ln 
# or can be run with liquid together
nigiri start --liquid --ln

# get an address from LND
nigiri lnd newaddress p2wkh

# get an address from Core Lightning
nigiri cln newaddr

# fund LND one-shot
nigiri faucet `nigiri lnd newaddress p2wkh | jq -r .address`

# fund Core Lightning one-shot
nigiri faucet `nigiri cln newaddr | jq -r .bech32` 0.1
```


## Is ready fro review?

- [x] add one instances
 of LND with `noseedbackup` and one of Core Lightning.
- [x] Wrap `lncli` & `lighting-cli` command-line interfaces under `nigiri lnd` and/or `nigiri cln`
- [x] Add Core Lighting service 
- [x] Allow to fund cln & lnd one command `nigiri faucet cln` or `nigiri faucet lnd` 
- [x] Update README documentation




This PR is ready to review/merge, but worth mentioning other "nice to have tasks" that need chopsticks changes

- [ ] Automate node funding and channel creation between nodes
- [ ] Intercept somehow on-chain transaction from node and trigger block mining 


**Bonus**
This also closes #142 