### PR TITLE
Fixed Core Lightning log instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ $ nigiri logs chopsticks-liquid
 
 ```bash
 # Core Lightning
-$ nigiri logs cln
+$ nigiri logs lightningd
 # LND
 $ nigiri logs lnd
 ```


### PR DESCRIPTION
When I run `nigiri logs cln`, I get:

```
ERROR: No such service: cln
exit status 1
```

If I try `nigiri logs lightningd`, it works. I edited the README to reflect this.

