### PR TITLE
lnd: listen on 0.0.0.0 and rename docker-compose service name from lightningd to cln

### DIFF
--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -167,7 +167,7 @@ services:
 
   lnd:
     container_name: lnd
-    image: lightninglabs/lnd:v0.14.3-beta
+    image: lightninglabs/lnd:v0.15.0-beta
     user: 1000:1000
     depends_on:
       - bitcoin
@@ -179,9 +179,10 @@ services:
     stop_grace_period: 5m30s
     ports:
       - "9735:9735" # p2p
-      - "10009:10009" # grpc
+      - "10009:10009" # grpc"
+      - "18080:18080" # rest"
 
-  lightningd:
+  cln:
     container_name: cln
     image: elementsproject/lightningd:latest
     environment:

--- a/cmd/nigiri/resources/lnd.conf
+++ b/cmd/nigiri/resources/lnd.conf
@@ -1,6 +1,12 @@
 [Application Options]
+alias=nigiri
 debuglevel=debug
 noseedbackup=1
+
+# RPC open to all connections on Port 10009
+rpclisten=0.0.0.0:10009
+# REST open to all connections on Port 18080
+restlisten=0.0.0.0:18080
 
 
 [Bitcoin]

--- a/cmd/nigiri/start.go
+++ b/cmd/nigiri/start.go
@@ -52,7 +52,7 @@ func startAction(ctx *cli.Context) error {
 		// LND
 		servicesToRun = append(servicesToRun, "lnd")
 		// Core Lightning Network
-		servicesToRun = append(servicesToRun, "lightningd")
+		servicesToRun = append(servicesToRun, "cln")
 	}
 
 	if isCI {
@@ -67,7 +67,7 @@ func startAction(ctx *cli.Context) error {
 			// LND
 			servicesToRun = append(servicesToRun, "lnd")
 			// Core Lightning Network
-			servicesToRun = append(servicesToRun, "lightningd")
+			servicesToRun = append(servicesToRun, "cln")
 		}
 	}
 


### PR DESCRIPTION
It closes https://github.com/vulpemventures/nigiri/issues/157
It fixes https://github.com/vulpemventures/nigiri/pull/154
