### PR TITLE
Add `lnd` domain for TLS certificate

### DIFF
--- a/cmd/nigiri/resources/lnd.conf
+++ b/cmd/nigiri/resources/lnd.conf
@@ -8,6 +8,9 @@ rpclisten=0.0.0.0:10009
 # REST open to all connections on Port 18080
 restlisten=0.0.0.0:18080
 
+; Add `lnd` domain for TLS certificate to allow RPC connections from other
+; containers.
+tlsextradomain=lnd
 
 [Bitcoin]
 ; If the Bitcoin chain should be active. Atm, only a single chain can be


### PR DESCRIPTION
To allow to extend nigiri setup and allow RPC connections to LND from other containers `lnd` domain has to be added for a TLS certificate.

A new certificate will have `DNS:lnd`:
```sh
$ openssl x509 -noout -text -in tls.cert 
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            1c:d6:bb:1f:1c:37:56:4c:60:d1:07:29:6d:ba:05:0d
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: O = lnd autogenerated cert, CN = 1ae06b21a92e
        Validity
            Not Before: Sep 28 10:46:25 2022 GMT
            Not After : Nov 23 10:46:25 2023 GMT
        Subject: O = lnd autogenerated cert, CN = 1ae06b21a92e
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:64:17:a1:52:0d:45:a6:a5:9b:15:58:68:9d:ac:
                    c1:7a:97:19:8c:58:d2:1e:38:c0:09:f5:43:d9:48:
                    87:60:b7:9f:ae:1c:74:42:25:49:64:90:5d:2f:02:
                    b4:41:81:c9:04:e3:c1:89:f6:53:fa:3a:5f:55:41:
                    59:59:2c:8c:f1
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment, Certificate Sign
            X509v3 Extended Key Usage: 
                TLS Web Server Authentication
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Subject Key Identifier: 
                58:3D:46:AB:E5:62:52:03:32:6B:E6:28:00:B3:E3:24:17:F9:16:AD
            X509v3 Subject Alternative Name: 
                DNS:1ae06b21a92e, DNS:localhost, DNS:lnd, DNS:unix, DNS:unixpacket, DNS:bufconn, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1, IP Address:172.23.0.2
    Signature Algorithm: ecdsa-with-SHA256
    Signature Value:
        30:46:02:21:00:f2:f5:cf:26:64:3f:a3:3e:1d:8b:1a:d4:b4:
        27:ef:fe:27:51:cd:5d:62:cd:9a:7e:9d:8e:c3:79:4a:50:0d:
        05:02:21:00:b8:00:1e:55:8c:03:81:ee:80:bd:27:18:b9:10:
        b6:f7:85:2b:02:08:3e:79:f7:ab:6f:2d:a1:5a:8e:75:3d:81
```