### PR TITLE
Fix generate bitcoin rpc

### DIFF
--- a/cmd/nigiri/rpc.go
+++ b/cmd/nigiri/rpc.go
@@ -49,7 +49,7 @@ func rpcAction(ctx *cli.Context) error {
 		rpcArgs = []string{"exec", "liquid", "elements-cli", "-datadir=config", "-rpcwallet=" + rpcWallet}
 	}
 	if generate > 0 {
-		rpcArgs = append(rpcArgs, "-generate="+fmt.Sprint(generate))
+		rpcArgs = append(rpcArgs, "-generate", fmt.Sprint(generate))
 	}
 	if named {
 		rpcArgs = append(rpcArgs, "-named")


### PR DESCRIPTION
`nigiri rpc --generate 2` generates only one block because it runs bitcoin as `bitcoin-cli -generate=2` but it should be `bitcoin-cli -generate 2`

The PR fixes this:
```sh
$ nigiri rpc --liquid --generate 2
{
  "address": "el1qq2s6zmsm0rvh4rsh37pd5s4dg4usel94de8plefcu0cmx60awh2p8aaaw8aa3295uaxp04kjy2jp0egx6wcx5yua8frgp3ynj",
  "blocks": [
    "7e667684f56740fcbb38a9221bc791f3c38ccd26c26f77257f4256b82f17e7d1",
    "4ec2a0120113543e455458e5c7a659bec470f7c16a314d1664e10a74b11697f3"
  ]
}
$ nigiri rpc --generate 2
{
  "address": "bcrt1qh338vm2gzgf4mma8d9ywzm65lp8pwpsljfvtnc",
  "blocks": [
    "62861dae93f1a72417c9468299db45484e02bc9c4a455d4c37cf3a74c7935e49",
    "46117a1311f2d0cca5d8e9cacbb58b5d5d16cc8b4d499f4098ef6318a8e1fa48"
  ]
}
```