### PR TITLE
Fix CLN p2p port

### DIFF
--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -186,15 +186,15 @@ services:
     container_name: cln
     image: elementsproject/lightningd:latest
     environment:
-      LIGHTNINGD_PORT: 9935
       EXPOSE_TCP: "true"
     command: 
-      - --network=regtest 
       - --alias=nigiri
+      - --bind-addr=0.0.0.0:9935
       - --bitcoin-rpcconnect=bitcoin:18443
-      - --bitcoin-rpcuser=admin1 
       - --bitcoin-rpcpassword=123 
-      - --log-level=debug 
+      - --bitcoin-rpcuser=admin1
+      - --log-level=debug
+      - --network=regtest
     depends_on:
       - bitcoin
     ports:


### PR DESCRIPTION
`LIGHTNINGD_PORT` is not consumed by https://github.com/ElementsProject/lightning/blob/master/tools/docker-entrypoint.sh nor `lightningd`.
Before the fix:
```sh
$ nigiri lnd connect `nigiri cln getinfo | jq -r .id`@cln:9935
[lncli] rpc error: code = Unknown desc = dial tcp 172.24.0.4:9935: connect: connection refused
exit status 1
```

After the fix:
```sh
$ nigiri lnd connect `nigiri cln getinfo | jq -r .id`@cln:9935
{

}
```