### PR TITLE
fix: /bin/bash: no such file or directory

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Adds support for other OSes where the bash binary
might be located in a different path