### PR TITLE
Update Bitcoin Core to v26.1

### DIFF
--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -1,9 +1,9 @@
-version: '3.8'
+name: nigiri
 services:
 
   # RPC daemon
   bitcoin:
-    image: lncm/bitcoind:v24.0.1
+    image: lncm/bitcoind:v26.1
     container_name: bitcoin
     user: 1000:1000
     restart: on-failure


### PR DESCRIPTION
This updates to latest published version (not maintained by us, but lncm working group)

bonus: remove version field from compose to remove warning