### PR TITLE
Use `lightninglabs/lnd:v0.18.3-beta` image

### DIFF
--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -166,7 +166,7 @@ services:
 
   lnd:
     container_name: lnd
-    image: ghcr.io/vulpemventures/lnd:v0.16.2-beta
+    image: lightninglabs/lnd:v0.18.3-beta
     user: 1000:1000
     depends_on:
       - bitcoin


### PR DESCRIPTION
Switching to use the latest official image from Lightning labs.

Are any reasons not to use it? The only difference in the docker file I see is that `ghcr.io/vulpemventures/lnd` has:
```sh
make release-install tags="signrpc walletrpc chainrpc invoicesrpc"
```
when lnd docker file will default `tags` to `autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc monitoring peersrpc kvdb_postgres kvdb_etcd kvdb_sqlite`
https://github.com/lightningnetwork/lnd/blob/4c4840286849321f51724abcec9bdb9d6d28fb8f/make/release_flags.mk#L36