### PR TITLE
Update Bitcoin Core to v28.0 + Use `getumbrel/bitcoind` docker image

### DIFF
--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   # RPC daemon
   bitcoin:
-    image: lncm/bitcoind:v26.1
+    image: getumbrel/bitcoind:v28.0
     container_name: bitcoin
     user: 1000:1000
     restart: on-failure


### PR DESCRIPTION
Use `getumbrel/bitcoind:v28.0` image in compose file.

@tiero @altafan  please review