### PR TITLE
fix: handle volume permissions correctly

### DIFF
--- a/cmd/nigiri/main.go
+++ b/cmd/nigiri/main.go
@@ -258,11 +258,14 @@ func cleanAndExpandPath(path string) string {
 func runDockerCompose(composePath string, args ...string) *exec.Cmd {
 	var cmd *exec.Cmd
 
+	// Try to find docker-compose binary
 	_, err := exec.LookPath("docker-compose")
-	if err != nil {
-		cmd = exec.Command("docker", append([]string{"compose", "-f", composePath}, args...)...)
-	} else {
+	if err == nil {
+		// docker-compose found, use it
 		cmd = exec.Command("docker-compose", append([]string{"-f", composePath}, args...)...)
+	} else {
+		// docker-compose not found, fallback to 'docker compose'
+		cmd = exec.Command("docker", append([]string{"compose", "-f", composePath}, args...)...)
 	}
 	return cmd
 }

--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -5,7 +5,6 @@ services:
   bitcoin:
     image: getumbrel/bitcoind:v28.0
     container_name: bitcoin
-    user: 1000:1000
     restart: on-failure
     stop_grace_period: 30s
     ports:
@@ -19,7 +18,6 @@ services:
 
   liquid:
     image: ghcr.io/vulpemventures/elements:latest
-    user: 1000:1000
     container_name: liquid
     command:
       - -datadir=config
@@ -167,7 +165,6 @@ services:
   lnd:
     container_name: lnd
     image: lightninglabs/lnd:v0.18.3-beta
-    user: 1000:1000
     depends_on:
       - bitcoin
     volumes:
@@ -184,7 +181,6 @@ services:
   tap:
     container_name: tap
     image: ghcr.io/vulpemventures/tapd:v0.2.0
-    user: 1000:1000
     depends_on:
       - bitcoin
       - lnd
@@ -208,7 +204,6 @@ services:
   cln:
     container_name: cln
     image: elementsproject/lightningd:latest
-    user: 1000:1000
     environment:
       EXPOSE_TCP: "true"
     command: 

--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   bitcoin:
     image: getumbrel/bitcoind:v28.0
     container_name: bitcoin
+    user: "${UID:-1000}:${GID:-1000}"
     restart: on-failure
     stop_grace_period: 30s
     ports:
@@ -19,6 +20,7 @@ services:
   liquid:
     image: ghcr.io/vulpemventures/elements:latest
     container_name: liquid
+    user: "${UID:-1000}:${GID:-1000}"
     command:
       - -datadir=config
     ports:
@@ -165,6 +167,7 @@ services:
   lnd:
     container_name: lnd
     image: lightninglabs/lnd:v0.18.4-beta.rc2
+    user: "${UID:-1000}:${GID:-1000}"
     depends_on:
       - bitcoin
     volumes:
@@ -181,6 +184,7 @@ services:
   tap:
     container_name: tap
     image: lightninglabs/taproot-assets:v0.4.1
+    user: "${UID:-1000}:${GID:-1000}"
     depends_on:
       - bitcoin
       - lnd
@@ -204,6 +208,7 @@ services:
   cln:
     container_name: cln
     image: elementsproject/lightningd:latest
+    user: "${UID:-1000}:${GID:-1000}"
     environment:
       EXPOSE_TCP: "true"
     command: 


### PR DESCRIPTION
# Fix volume permissions for Linux users

This PR fixes permission issues with mounted volumes, particularly on Linux systems where users were experiencing root ownership problems.

## Testing on macOS

```bash
# 1. Make sure Docker Desktop is running
# 2. Build and test
make build

# 3. Run test cycle with the new binary
sudo rm -rf ~/Library/Application\ Support/Nigiri
./build/nigiri-darwin-arm64 stop --delete
./build/nigiri-darwin-arm64 start

# 4. Verify permissions (should show your user, not root)
ls -la ~/Library/Application\ Support/Nigiri/volumes/bitcoin/
```

Expected output should show your user owning the files:
```
drwxr-x---   4 <your-user>  staff  128 Dec 18 19:19 .
drwxr-x---   7 <your-user>  staff  224 Dec 18 19:19 ..
-rw-r-----   1 <your-user>  staff  295 Dec 18 19:19 bitcoin.conf
drwx------  12 <your-user>  staff  384 Dec 18 19:19 regtest
```