### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -110,12 +111,10 @@ func (s *State) GetString(key string) (string, error) {
 	return stateData[key], nil
 }
 
-func merge(maps ...map[string]string) map[string]string {
+func merge(mapsParam ...map[string]string) map[string]string {
 	merge := make(map[string]string)
-	for _, m := range maps {
-		for k, v := range m {
-			merge[k] = v
-		}
+	for _, m := range mapsParam {
+		maps.Copy(merge, m)
 	}
 	return merge
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.
