### PR TITLE
Add arkade-explorer to the Ark service stack

### DIFF
--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -289,6 +289,21 @@ services:
     ports:
       - "6060:6060"
 
+  ark-explorer:
+    container_name: ark-explorer
+    image: ghcr.io/arklabshq/arkade-explorer:latest
+    restart: unless-stopped
+    depends_on:
+      - ark
+    command:
+      - sh
+      - -c
+      - |
+        sed -i 's|https://arkade.computer|http://localhost:7070|g' /usr/share/nginx/html/assets/*.js &&
+        nginx -g 'daemon off;'
+    ports:
+      - "7080:80"
+
   ark:
     container_name: ark
     image: ghcr.io/arkade-os/arkd:v0.8.11

--- a/cmd/nigiri/start.go
+++ b/cmd/nigiri/start.go
@@ -143,7 +143,7 @@ func startAction(ctx *cli.Context) error {
 	}
 
 	if effectiveFlags.Ark {
-		services = append(services, "ark", "ark-wallet")
+		services = append(services, "ark", "ark-wallet", "ark-explorer")
 	}
 
 	bashCmd := runDockerCompose(composePath, append([]string{"up", "-d"}, services...)...)


### PR DESCRIPTION
## Summary
- Adds the [arkade-explorer](https://github.com/ArkLabsHQ/arkade-explorer) container (`ghcr.io/arklabshq/arkade-explorer:latest`) to the docker-compose, started automatically when `--ark` is enabled
- Explorer available at `http://localhost:7080`
- Patches the Vite-baked API URLs at container startup to point at the local arkd (`http://localhost:7070`)
- Bumps `arkd` and `ark-wallet` images to `v0.9.0-rc.1` and `nbxplorer` to `2.6.0`

## Test plan
- [ ] Run `nigiri start --ark` and verify `ark-explorer` container is running
- [ ] Open `http://localhost:7080` and confirm the explorer loads
- [ ] Verify the explorer connects to the local arkd at `localhost:7070`
- [ ] Run `nigiri start` (without `--ark`) and verify `ark-explorer` is NOT started