### PR TITLE
Enable CLN REST API with required configuration flags

### DIFF
--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -223,6 +223,9 @@ services:
       - --network=regtest
       - --grpc-host=0.0.0.0
       - --grpc-port=9936
+      - --clnrest-protocol=http
+      - --clnrest-host=0.0.0.0
+      - --clnrest-port=9835
     depends_on:
       - bitcoin
     ports:


### PR DESCRIPTION
Add the necessary flags to expose Core Lightning's REST server:
- clnrest-protocol: HTTP
- clnrest-host: Listen on all interfaces
- clnrest-port: 9835 (exposed in container port mapping)

Per Core Lightning documentation, clnrest-port must be specified to enable the plugin; without it, the plugin disables itself.

Reference: https://docs.corelightning.org/docs/rest