### PR TITLE
start nbxplorer when ark is started

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Go to http://localhost:5000 to quickly inspect the Bitcoin blockchain
 Want more? Add Elements/Liquid, Lightning nodes, or Ark:
 
 ```bash
-nigiri start --ark --liquid  # Add Elements/Liquid sidechain
-nigiri start --ark --ln      # Add Lightning Network nodes
+nigiri start --ark --liquid  # Add both Ark and Elements/Liquid sidechain
+nigiri start --ark --ln      # Add both Ark and Lightning Network nodes
 nigiri start --liquid --ln   # Add both Liquid and Lightning
 nigiri start --ark --liquid --ln  # Add all features
 ```

--- a/cmd/nigiri/start.go
+++ b/cmd/nigiri/start.go
@@ -143,7 +143,7 @@ func startAction(ctx *cli.Context) error {
 	}
 
 	if effectiveFlags.Ark {
-		services = append(services, "ark", "ark-wallet", "ark-explorer")
+		services = append(services, "ark", "ark-wallet", "ark-explorer", "nbxplorer")
 	}
 
 	bashCmd := runDockerCompose(composePath, append([]string{"up", "-d"}, services...)...)


### PR DESCRIPTION
This PR adds nbxplorer to the list of services to be started when nigiri is started with `--ark`

Problem: nbxplorer was not started when ark is started, but later on the arkd setup we `waitForNbxplorerSync()`

@altafan please review