### PR TITLE
Add NIGIRI_DATADIR env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ nigiri update
 ```
 
 Nigiri uses the default directory `~/.nigiri` to store configuration files and docker-compose files.
-To set a custom directory use the `--datadir` flag.
+To set a custom directory use the `--datadir` flag or `NIGIRI_DATADIR` environment variable.
+If both are present, `--datadir` takes precedence.
 
 Run the `help` command to see the full list of available flags.
 

--- a/cmd/nigiri/main.go
+++ b/cmd/nigiri/main.go
@@ -37,9 +37,10 @@ var lnFlag = cli.BoolFlag{
 }
 
 var datadirFlag = cli.StringFlag{
-	Name:  "datadir",
-	Usage: "use different data directory",
-	Value: config.DefaultDatadir,
+	Name:    "datadir",
+	Usage:   "use different data directory",
+	Value:   config.DefaultDatadir,
+	EnvVars: []string{"NIGIRI_DATADIR"},
 }
 
 var arkFlag = cli.BoolFlag{


### PR DESCRIPTION
This allows a user to specify Nigiri's data directory without modifying existing scripts to use the `--datadir` flag. 