### PR TITLE
Replace bitcoin electrs/esplora with fulcrum + mempool stack

### DIFF
--- a/cmd/nigiri/main.go
+++ b/cmd/nigiri/main.go
@@ -53,6 +53,7 @@ var arkFlag = cli.BoolFlag{
 //go:embed resources/bitcoin.conf
 //go:embed resources/elements.conf
 //go:embed resources/lnd.conf
+//go:embed resources/esplora-relay.conf
 var f embed.FS
 
 func main() {
@@ -152,6 +153,10 @@ func provisionResourcesToDatadir(datadir string) error {
 		filepath.Join(datadir, "volumes", "ark", "wallet"),
 		filepath.Join(datadir, "volumes", "nbxplorer"),
 		filepath.Join(datadir, "volumes", "postgres"),
+		filepath.Join(datadir, "volumes", "fulcrum"),
+		filepath.Join(datadir, "volumes", "mempool-mariadb"),
+		filepath.Join(datadir, "volumes", "mempool-api"),
+		filepath.Join(datadir, "volumes", "esplora-relay"),
 	}
 
 	for _, dir := range volumeDirs {
@@ -194,6 +199,16 @@ func provisionResourcesToDatadir(datadir string) error {
 	if err := copyFromResourcesToDatadir(
 		filepath.Join("resources", "lnd.conf"),
 		filepath.Join(datadir, "volumes", "lnd", "lnd.conf"),
+		uid,
+		gid,
+	); err != nil {
+		return err
+	}
+
+	// copy esplora-relay nginx config so chopsticks can hit mempool-api's /api/* surface
+	if err := copyFromResourcesToDatadir(
+		filepath.Join("resources", "esplora-relay.conf"),
+		filepath.Join(datadir, "volumes", "esplora-relay", "default.conf"),
 		uid,
 		gid,
 	); err != nil {

--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -32,36 +32,108 @@ services:
       - ./volumes/elements/:/config
     restart: unless-stopped
 
-  # Block explorer server
-  electrs:
-    image: ghcr.io/vulpemventures/electrs:latest
-    container_name: electrs
-    entrypoint:
-      - /build/electrs
-    command:
-      - -vvvv
-      - --network
-      - regtest
-      - --daemon-dir
-      - /config
-      - --daemon-rpc-addr
-      - bitcoin:18443
-      - --cookie
-      - admin1:123
-      - --http-addr
-      - 0.0.0.0:30000
-      - --electrum-rpc-addr
-      - 0.0.0.0:50000
-      - --cors
-      - "*"
-      - --jsonrpc-import
+  # Bitcoin Electrum protocol server
+  fulcrum:
+    image: cculianu/fulcrum:latest
+    container_name: fulcrum
     depends_on:
       - bitcoin
+    command:
+      - Fulcrum
+      - --datadir
+      - /data
+      - --bitcoind
+      - bitcoin:18443
+      - --rpcuser
+      - admin1
+      - --rpcpassword
+      - "123"
+      - --tcp
+      - 0.0.0.0:50001
+      - --ws
+      - 0.0.0.0:50003
+      - --peering
+      - "0"
+      - --announce
+      - "0"
     ports:
-      - 50000:50000
-      - 30000:30000
+      - 50000:50001
+      - 50003:50003
     volumes:
-      - ./volumes/bitcoin/:/config
+      - ./volumes/fulcrum:/data
+    restart: unless-stopped
+
+  # MariaDB backing store for mempool-api
+  mempool-mariadb:
+    image: mariadb:10.5
+    container_name: mempool-mariadb
+    environment:
+      MYSQL_DATABASE: mempool
+      MYSQL_USER: mempool
+      MYSQL_PASSWORD: mempool
+      MYSQL_ROOT_PASSWORD: moneyprintergobrrr
+    volumes:
+      - ./volumes/mempool-mariadb:/var/lib/mysql
+    restart: unless-stopped
+
+  # mempool API — serves esplora-compatible REST under /api/*
+  mempool-api:
+    image: mempool/backend:v3.2.1
+    container_name: mempool-api
+    user: "${UID:-1000}:${GID:-1000}"
+    init: true
+    depends_on:
+      - mempool-mariadb
+      - fulcrum
+      - bitcoin
+    command: "./wait-for-it.sh mempool-mariadb:3306 --timeout=720 --strict -- ./start.sh"
+    environment:
+      # Bitcoin Core RPC (regtest)
+      CORE_RPC_HOST: "bitcoin"
+      CORE_RPC_PORT: "18443"
+      CORE_RPC_USERNAME: "admin1"
+      CORE_RPC_PASSWORD: "123"
+      CORE_RPC_TIMEOUT: "120000"
+      # Electrum backend (Fulcrum)
+      MEMPOOL_BACKEND: "electrum"
+      ELECTRUM_HOST: "fulcrum"
+      ELECTRUM_PORT: "50001"
+      ELECTRUM_TLS_ENABLED: "false"
+      # Database
+      DATABASE_ENABLED: "true"
+      DATABASE_HOST: "mempool-mariadb"
+      DATABASE_PORT: "3306"
+      DATABASE_DATABASE: "mempool"
+      DATABASE_USERNAME: "mempool"
+      DATABASE_PASSWORD: "mempool"
+      DATABASE_TIMEOUT: "300000"
+      # Mempool core
+      MEMPOOL_NETWORK: "regtest"
+      MEMPOOL_HTTP_PORT: "8999"
+      MEMPOOL_CACHE_DIR: "/backend/cache"
+      MEMPOOL_CACHE_ENABLED: "true"
+      MEMPOOL_INDEXING_BLOCKS_AMOUNT: "-1"
+      MEMPOOL_POLL_RATE_MS: "2000"
+      MEMPOOL_ALLOW_UNREACHABLE: "true"
+      STATISTICS_ENABLED: "false"
+      LIGHTNING_ENABLED: "false"
+    volumes:
+      - ./volumes/mempool-api:/backend/cache
+    ports:
+      - 8999:8999
+    restart: unless-stopped
+
+  # nginx relay: rewrites unprefixed paths to /api/* so chopsticks (and any
+  # legacy esplora-style client) keep working unchanged against mempool-api.
+  esplora-relay:
+    image: nginx:alpine
+    container_name: esplora-relay
+    depends_on:
+      - mempool-api
+    volumes:
+      - ./volumes/esplora-relay/default.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - 30000:80
     restart: unless-stopped
 
   electrs-liquid:
@@ -97,16 +169,21 @@ services:
       - ./volumes/elements/:/config
     restart: unless-stopped
 
-  # Block explorer frontend
-  esplora:
-    image: ghcr.io/vulpemventures/esplora:latest
-    container_name: esplora
+  # Block explorer frontend (mempool)
+  mempool-web:
+    image: mempool/frontend:v3.2.1
+    container_name: mempool-web
+    user: "${UID:-1000}:${GID:-1000}"
+    init: true
     depends_on:
-      - chopsticks
+      - mempool-api
+    command: "./wait-for mempool-mariadb:3306 --timeout=720 -- nginx -g 'daemon off;'"
     environment:
-      API_URL: http://localhost:3000
+      FRONTEND_HTTP_PORT: "80"
+      BACKEND_MAINNET_HTTP_HOST: "mempool-api"
+      BACKEND_MAINNET_HTTP_PORT: "8999"
     ports:
-      - 5000:5000
+      - 5000:80
     restart: unless-stopped
 
   esplora-liquid:
@@ -131,12 +208,12 @@ services:
       - --rpc-addr
       - bitcoin:18443
       - --electrs-addr
-      - electrs:30000
+      - esplora-relay:80
       - --addr
       - 0.0.0.0:3000
     depends_on:
       - bitcoin
-      - electrs
+      - esplora-relay
     ports:
       - 3000:3000
     restart: unless-stopped

--- a/cmd/nigiri/resources/esplora-relay.conf
+++ b/cmd/nigiri/resources/esplora-relay.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80 default_server;
+
+    # chopsticks (and any legacy esplora client) sends unprefixed paths like
+    # /address/:addr/utxo or /tx/:txid. mempool-api serves the same surface
+    # under /api/*, so we prepend the prefix and proxy through.
+    location / {
+        rewrite ^(.*)$ /api$1 break;
+        proxy_pass http://mempool-api:8999;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+    }
+}

--- a/cmd/nigiri/start.go
+++ b/cmd/nigiri/start.go
@@ -195,6 +195,13 @@ func startAction(ctx *cli.Context) error {
 		}
 
 		filteredEndpoints[name] = endpoint
+
+		// fulcrum exposes both TCP Electrum (the auto-derived endpoint above)
+		// and WebSocket Electrum on a second port. Surface the WS URL with an
+		// explicit scheme so users know not to point HTTP clients at it.
+		if name == "fulcrum" {
+			filteredEndpoints["fulcrum (ws)"] = "ws://localhost:50003"
+		}
 	}
 
 	// Display endpoints

--- a/cmd/nigiri/start.go
+++ b/cmd/nigiri/start.go
@@ -122,16 +122,26 @@ func startAction(ctx *cli.Context) error {
 		}
 	}
 
+	bitcoinExplorerStack := []string{
+		"bitcoin",
+		"fulcrum",
+		"mempool-mariadb",
+		"mempool-api",
+		"esplora-relay",
+		"chopsticks",
+	}
+
 	var services []string
 
 	if effectiveFlags.Ci {
-		services = []string{"bitcoin", "electrs", "chopsticks"}
+		services = append(services, bitcoinExplorerStack...)
 
 		if effectiveFlags.Liquid {
 			services = append(services, "liquid", "electrs-liquid", "chopsticks-liquid")
 		}
 	} else {
-		services = []string{"bitcoin", "electrs", "chopsticks", "esplora"}
+		services = append(services, bitcoinExplorerStack...)
+		services = append(services, "mempool-web")
 
 		if effectiveFlags.Liquid {
 			services = append(services, "liquid", "electrs-liquid", "chopsticks-liquid", "esplora-liquid")

--- a/internal/docker/mock_client.go
+++ b/internal/docker/mock_client.go
@@ -56,11 +56,13 @@ func (m *MockClient) GetEndpoints(composePath string) (map[string]string, error)
 	}
 	// Default mock endpoints
 	return map[string]string{
-		"bitcoin":    "localhost:18443",
-		"electrs":    "localhost:3002",
-		"esplora":    "localhost:3000",
-		"chopsticks": "localhost:3000",
-		"ark":        "localhost:7070",
+		"bitcoin":         "localhost:18443",
+		"fulcrum":         "localhost:50000",
+		"mempool-api":     "localhost:8999",
+		"mempool-web":     "localhost:5000",
+		"esplora-relay":   "localhost:30000",
+		"chopsticks":      "localhost:3000",
+		"ark":             "localhost:7070",
 	}, nil
 }
 
@@ -72,10 +74,14 @@ func (m *MockClient) GetPortsForService(composePath string, serviceName string) 
 	switch serviceName {
 	case "bitcoin":
 		return []string{"18443"}, nil
-	case "electrs":
-		return []string{"3002"}, nil
-	case "esplora":
-		return []string{"3000"}, nil
+	case "fulcrum":
+		return []string{"50000", "50003"}, nil
+	case "mempool-api":
+		return []string{"8999"}, nil
+	case "mempool-web":
+		return []string{"5000"}, nil
+	case "esplora-relay":
+		return []string{"30000"}, nil
 	case "chopsticks":
 		return []string{"3000"}, nil
 	case "ark":

--- a/test/start_stop_test.go
+++ b/test/start_stop_test.go
@@ -102,12 +102,18 @@ services:
     container_name: bitcoin
   liquid:
     image: ghcr.io/vulpemventures/elements:latest
-  electrs:
-    image: vulpemventures/electrs:latest
+  fulcrum:
+    image: cculianu/fulcrum:latest
+  mempool-mariadb:
+    image: mariadb:10.5
+  mempool-api:
+    image: mempool/backend:v3.2.1
+  mempool-web:
+    image: mempool/frontend:v3.2.1
+  esplora-relay:
+    image: nginx:alpine
   chopsticks:
     image: vulpemventures/nigiri-chopsticks:latest
-  esplora:
-    image: vulpemventures/esplora:latest
   lnd:
     image: lightninglabs/lnd:latest
   tap:
@@ -198,9 +204,11 @@ func TestDataDirSetup(t *testing.T) {
 	// Verify essential services are defined in docker-compose.yml
 	essentialServices := []string{
 		"bitcoin:",
-		"electrs:",
+		"fulcrum:",
+		"mempool-api:",
+		"esplora-relay:",
 		"chopsticks:",
-		"esplora:",
+		"mempool-web:",
 	}
 
 	for _, service := range essentialServices {
@@ -242,7 +250,7 @@ func TestBasicStartStop(t *testing.T) {
 	mockClient.SetMockCmd(exec.Command("echo", "mock start"))
 
 	// Execute start command
-	mockClient.RunCompose(composePath, "up", "-d", "bitcoin", "electrs", "chopsticks", "esplora")
+	mockClient.RunCompose(composePath, "up", "-d", "bitcoin", "fulcrum", "mempool-mariadb", "mempool-api", "esplora-relay", "chopsticks", "mempool-web")
 
 	// Verify the correct Docker commands were called
 	composePath, args, ok := mockClient.GetLastCommand()
@@ -256,7 +264,7 @@ func TestBasicStartStop(t *testing.T) {
 	}
 
 	// Check that the correct services were started
-	expectedArgs := []string{"up", "-d", "bitcoin", "electrs", "chopsticks", "esplora"}
+	expectedArgs := []string{"up", "-d", "bitcoin", "fulcrum", "mempool-mariadb", "mempool-api", "esplora-relay", "chopsticks", "mempool-web"}
 	if !stringSliceEqual(args, expectedArgs) {
 		t.Errorf("Expected args %v, got %v", expectedArgs, args)
 	}
@@ -339,7 +347,7 @@ func TestServiceCombinations(t *testing.T) {
 			liquid:           false,
 			ln:               false,
 			ark:              false,
-			expectedServices: []string{"bitcoin", "electrs", "chopsticks", "esplora"},
+			expectedServices: []string{"bitcoin", "fulcrum", "mempool-mariadb", "mempool-api", "esplora-relay", "chopsticks", "mempool-web"},
 		},
 		{
 			name:   "With Liquid",
@@ -347,7 +355,7 @@ func TestServiceCombinations(t *testing.T) {
 			ln:     false,
 			ark:    false,
 			expectedServices: []string{
-				"bitcoin", "electrs", "chopsticks", "esplora",
+				"bitcoin", "fulcrum", "mempool-mariadb", "mempool-api", "esplora-relay", "chopsticks", "mempool-web",
 				"liquid", "electrs-liquid", "chopsticks-liquid", "esplora-liquid",
 			},
 		},
@@ -357,7 +365,7 @@ func TestServiceCombinations(t *testing.T) {
 			ln:     true,
 			ark:    false,
 			expectedServices: []string{
-				"bitcoin", "electrs", "chopsticks", "esplora",
+				"bitcoin", "fulcrum", "mempool-mariadb", "mempool-api", "esplora-relay", "chopsticks", "mempool-web",
 				"lnd", "tap", "cln",
 			},
 		},
@@ -367,7 +375,7 @@ func TestServiceCombinations(t *testing.T) {
 			ln:     false,
 			ark:    true,
 			expectedServices: []string{
-				"bitcoin", "electrs", "chopsticks", "esplora",
+				"bitcoin", "fulcrum", "mempool-mariadb", "mempool-api", "esplora-relay", "chopsticks", "mempool-web",
 				"ark",
 			},
 		},
@@ -377,7 +385,7 @@ func TestServiceCombinations(t *testing.T) {
 			ln:     true,
 			ark:    true,
 			expectedServices: []string{
-				"bitcoin", "electrs", "chopsticks", "esplora",
+				"bitcoin", "fulcrum", "mempool-mariadb", "mempool-api", "esplora-relay", "chopsticks", "mempool-web",
 				"liquid", "electrs-liquid", "chopsticks-liquid", "esplora-liquid",
 				"lnd", "tap", "cln",
 				"ark",


### PR DESCRIPTION
## Summary

Drops the legacy bitcoin-side `electrs` and `esplora` services in favour of `fulcrum` (modern Electrum protocol) and the `mempool` stack (esplora-compatible REST + UI). The Liquid services (`electrs-liquid`, `esplora-liquid`, `chopsticks-liquid`) are deliberately left untouched.

## Architecture

```
                  ┌──> fulcrum (Electrum TCP 50000, WS 50003)
bitcoin (RPC) ────┤
                  └──> mempool-api (REST /api/*) <─┬── mempool-web (UI :5000)
                          ↑                        │
                          └── mempool-mariadb      │
                                                   │
chopsticks ──> esplora-relay (nginx :30000) ──[rewrite ^→/api]──┘
```

### Why the nginx relay
`chopsticks` reverse-proxies its `--electrs-addr` **verbatim** with no path manipulation (verified by reading `nigiri-chopsticks/router/electrs_handler.go`). Mempool serves esplora-compat endpoints under `/api/*` while electrs served them at the root. The `esplora-relay` (nginx) sits between chopsticks and mempool-api, prepending `/api` so:

- `nigiri faucet` / `mint` / `push` CLI commands keep working
- arkd's `ARKD_ESPLORA_URL: http://chopsticks:3000` keeps working with no env-var change

### Port mapping (legacy host ports preserved)
| Old (electrs/esplora) | New |
|---|---|
| `30000` electrs HTTP esplora | `esplora-relay` (nginx) → mempool-api |
| `50000` electrs Electrum TCP | `fulcrum` Electrum TCP |
| `5000` esplora UI | `mempool-web` UI |

New ports added: `50003` (fulcrum WS), `8999` (mempool-api).

## Files touched
- `cmd/nigiri/resources/docker-compose.yml` — service swap
- `cmd/nigiri/resources/esplora-relay.conf` — new nginx config (path rewrite to `/api/*`)
- `cmd/nigiri/main.go` — embed + provision the new resource and per-service volume dirs
- `cmd/nigiri/start.go` — bitcoin explorer service list (CI / non-CI)
- `internal/docker/mock_client.go` — updated mock endpoints/ports
- `test/start_stop_test.go` — updated fixtures and expected service lists

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./test/... -run 'TestDataDirSetup|TestBasicStartStop|TestServiceCombinations|TestStateManagement'` — all green
- [x] `docker compose -f cmd/nigiri/resources/docker-compose.yml config --quiet` — valid
- [ ] End-to-end smoke: `nigiri start` boots the new stack; `nigiri faucet <addr>` works (chopsticks → relay → mempool-api round-trip)
- [ ] `nigiri start --liquid` — liquid stack untouched, still works
- [ ] `nigiri start --ark` — arkd's ESPLORA_URL still resolves; wallet creation/funding flow works
- [ ] `nigiri start --ci` — headless explorer stack starts (no `mempool-web`)

## Notes / follow-ups
- Existing nigiri datadirs need `nigiri forget` before upgrade so the new `docker-compose.yml` and the `esplora-relay/default.conf` resource are re-provisioned.
- Mempool's frontend is configured with `BACKEND_MAINNET_HTTP_HOST=mempool-api` — the UI will label things as mainnet but talk to the regtest backend. We can revisit this if a regtest-native UX is needed.
- `STATISTICS_ENABLED` and `LIGHTNING_ENABLED` are both set to `false` to keep the regtest stack lean; toggle if needed.