### PR TITLE
Add electrum-ws WebSocket bridge for browser Electrum clients

### DIFF
--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -64,6 +64,24 @@ services:
       - ./volumes/bitcoin/:/config
     restart: unless-stopped
 
+  # WebSocket bridge for the bitcoin Electrum endpoint. Browser/JS clients
+  # cannot open raw TCP sockets, so websocat translates between WS text frames
+  # (one JSON-RPC per frame, no trailing newline — matching fulcrum's -w
+  # semantics) and electrs's line-delimited TCP Electrum protocol.
+  electrum-ws:
+    image: ghcr.io/vi/websocat:latest
+    container_name: electrum-ws
+    depends_on:
+      - electrs
+    command:
+      - --text
+      - --linemode-strip-newlines
+      - ws-l:0.0.0.0:50003
+      - tcp:electrs:50000
+    ports:
+      - 50003:50003
+    restart: unless-stopped
+
   electrs-liquid:
     image: ghcr.io/vulpemventures/electrs-liquid:latest
     container_name: electrs-liquid

--- a/cmd/nigiri/start.go
+++ b/cmd/nigiri/start.go
@@ -125,13 +125,13 @@ func startAction(ctx *cli.Context) error {
 	var services []string
 
 	if effectiveFlags.Ci {
-		services = []string{"bitcoin", "electrs", "chopsticks"}
+		services = []string{"bitcoin", "electrs", "electrum-ws", "chopsticks"}
 
 		if effectiveFlags.Liquid {
 			services = append(services, "liquid", "electrs-liquid", "chopsticks-liquid")
 		}
 	} else {
-		services = []string{"bitcoin", "electrs", "chopsticks", "esplora"}
+		services = []string{"bitcoin", "electrs", "electrum-ws", "chopsticks", "esplora"}
 
 		if effectiveFlags.Liquid {
 			services = append(services, "liquid", "electrs-liquid", "chopsticks-liquid", "esplora-liquid")

--- a/cmd/nigiri/start.go
+++ b/cmd/nigiri/start.go
@@ -184,6 +184,12 @@ func startAction(ctx *cli.Context) error {
 			continue
 		}
 
+		// WebSocket endpoints need an explicit scheme so users know not to point
+		// HTTP clients at them.
+		if name == "electrum-ws" {
+			endpoint = "ws://" + endpoint
+		}
+
 		filteredEndpoints[name] = endpoint
 	}
 

--- a/internal/docker/mock_client.go
+++ b/internal/docker/mock_client.go
@@ -56,11 +56,12 @@ func (m *MockClient) GetEndpoints(composePath string) (map[string]string, error)
 	}
 	// Default mock endpoints
 	return map[string]string{
-		"bitcoin":    "localhost:18443",
-		"electrs":    "localhost:3002",
-		"esplora":    "localhost:3000",
-		"chopsticks": "localhost:3000",
-		"ark":        "localhost:7070",
+		"bitcoin":     "localhost:18443",
+		"electrs":     "localhost:3002",
+		"electrum-ws": "localhost:50003",
+		"esplora":     "localhost:3000",
+		"chopsticks":  "localhost:3000",
+		"ark":         "localhost:7070",
 	}, nil
 }
 
@@ -74,6 +75,8 @@ func (m *MockClient) GetPortsForService(composePath string, serviceName string) 
 		return []string{"18443"}, nil
 	case "electrs":
 		return []string{"3002"}, nil
+	case "electrum-ws":
+		return []string{"50003"}, nil
 	case "esplora":
 		return []string{"3000"}, nil
 	case "chopsticks":

--- a/test/start_stop_test.go
+++ b/test/start_stop_test.go
@@ -104,6 +104,8 @@ services:
     image: ghcr.io/vulpemventures/elements:latest
   electrs:
     image: vulpemventures/electrs:latest
+  electrum-ws:
+    image: ghcr.io/vi/websocat:latest
   chopsticks:
     image: vulpemventures/nigiri-chopsticks:latest
   esplora:
@@ -199,6 +201,7 @@ func TestDataDirSetup(t *testing.T) {
 	essentialServices := []string{
 		"bitcoin:",
 		"electrs:",
+		"electrum-ws:",
 		"chopsticks:",
 		"esplora:",
 	}
@@ -242,7 +245,7 @@ func TestBasicStartStop(t *testing.T) {
 	mockClient.SetMockCmd(exec.Command("echo", "mock start"))
 
 	// Execute start command
-	mockClient.RunCompose(composePath, "up", "-d", "bitcoin", "electrs", "chopsticks", "esplora")
+	mockClient.RunCompose(composePath, "up", "-d", "bitcoin", "electrs", "electrum-ws", "chopsticks", "esplora")
 
 	// Verify the correct Docker commands were called
 	composePath, args, ok := mockClient.GetLastCommand()
@@ -256,7 +259,7 @@ func TestBasicStartStop(t *testing.T) {
 	}
 
 	// Check that the correct services were started
-	expectedArgs := []string{"up", "-d", "bitcoin", "electrs", "chopsticks", "esplora"}
+	expectedArgs := []string{"up", "-d", "bitcoin", "electrs", "electrum-ws", "chopsticks", "esplora"}
 	if !stringSliceEqual(args, expectedArgs) {
 		t.Errorf("Expected args %v, got %v", expectedArgs, args)
 	}
@@ -339,7 +342,7 @@ func TestServiceCombinations(t *testing.T) {
 			liquid:           false,
 			ln:               false,
 			ark:              false,
-			expectedServices: []string{"bitcoin", "electrs", "chopsticks", "esplora"},
+			expectedServices: []string{"bitcoin", "electrs", "electrum-ws", "chopsticks", "esplora"},
 		},
 		{
 			name:   "With Liquid",
@@ -347,7 +350,7 @@ func TestServiceCombinations(t *testing.T) {
 			ln:     false,
 			ark:    false,
 			expectedServices: []string{
-				"bitcoin", "electrs", "chopsticks", "esplora",
+				"bitcoin", "electrs", "electrum-ws", "chopsticks", "esplora",
 				"liquid", "electrs-liquid", "chopsticks-liquid", "esplora-liquid",
 			},
 		},
@@ -357,7 +360,7 @@ func TestServiceCombinations(t *testing.T) {
 			ln:     true,
 			ark:    false,
 			expectedServices: []string{
-				"bitcoin", "electrs", "chopsticks", "esplora",
+				"bitcoin", "electrs", "electrum-ws", "chopsticks", "esplora",
 				"lnd", "tap", "cln",
 			},
 		},
@@ -367,7 +370,7 @@ func TestServiceCombinations(t *testing.T) {
 			ln:     false,
 			ark:    true,
 			expectedServices: []string{
-				"bitcoin", "electrs", "chopsticks", "esplora",
+				"bitcoin", "electrs", "electrum-ws", "chopsticks", "esplora",
 				"ark",
 			},
 		},
@@ -377,7 +380,7 @@ func TestServiceCombinations(t *testing.T) {
 			ln:     true,
 			ark:    true,
 			expectedServices: []string{
-				"bitcoin", "electrs", "chopsticks", "esplora",
+				"bitcoin", "electrs", "electrum-ws", "chopsticks", "esplora",
 				"liquid", "electrs-liquid", "chopsticks-liquid", "esplora-liquid",
 				"lnd", "tap", "cln",
 				"ark",


### PR DESCRIPTION
## Summary

Adds a small `websocat` container (`electrum-ws`) that exposes the existing `electrs` TCP Electrum endpoint as a WebSocket on port `50003`. Browser/JS clients (which cannot open raw TCP) can now speak Electrum protocol against nigiri's bitcoin Electrum server with no other changes.

This is a **lightweight alternative** to PR #257 (`fulcrum` + `mempool` stack). Both PRs are intentionally left open so reviewers can pick which way to go:

|  | PR #257 (fulcrum + mempool) | This PR |
|---|---|---|
| Browser-accessible Electrum (WS) | ✅ via fulcrum | ✅ via websocat |
| Modern, fast Electrum server | ✅ fulcrum | ❌ keeps electrs |
| New explorer UI / esplora swap | ✅ mempool | ❌ unchanged |
| Touches chopsticks/arkd plumbing | ✅ (needs nginx relay) | ❌ zero changes |
| New container count | +5 | +1 |
| Net diff | ~190 lines | ~40 lines |

## Why websocat works transparently

Verified by reading the relevant sources:

- **Fulcrum's `-w` framing** (the de-facto Electrum-over-WS spec): one JSON-RPC message per WebSocket text frame, **no trailing newlines**. `ElectrumConnection::on_readyRead` calls `ws->readNextMessage()` and treats each frame as a complete message — it does *not* split frames on `\n`.
- **electrs TCP framing**: classic newline-delimited JSON-RPC, server writes `…json…\n`.
- **websocat's default behavior** with `-t --linemode-strip-newlines`:
  - Client → bridge → electrs: one JSON-RPC per WS frame → websocat appends `\n` writing to TCP → electrs's `readLine()` reads it cleanly.
  - electrs → bridge → client: electrs writes `…json…\n` → websocat reads one line, strips `\n`, emits one WS text frame → client receives exactly what fulcrum would have sent.

So a native Electrum-over-WS client written for fulcrum should connect to `ws://localhost:50003` unchanged.

## Files touched
- `cmd/nigiri/resources/docker-compose.yml` — new `electrum-ws` service (websocat)
- `cmd/nigiri/start.go` — adds `electrum-ws` to the bitcoin services list (CI + non-CI)
- `internal/docker/mock_client.go` — mock endpoint/port entry
- `test/start_stop_test.go` — fixtures + expected service lists updated

Liquid stack (`electrs-liquid`, `chopsticks-liquid`, `esplora-liquid`) is untouched.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./test/... -run 'TestDataDirSetup|TestBasicStartStop|TestServiceCombinations|TestStateManagement'`
- [x] `docker compose -f cmd/nigiri/resources/docker-compose.yml config --quiet`
- [ ] End-to-end smoke: `nigiri start` boots the new container; a JS Electrum-over-WS client connects to `ws://localhost:50003` and gets a `server.version` response
- [ ] `nigiri start --liquid` — Liquid stack untouched
- [ ] `nigiri start --ci` — headless mode includes `electrum-ws`
- [ ] `nigiri start --ark` — arkd unaffected (still talks to electrs HTTP via chopsticks)

## Notes / follow-ups
- Existing nigiri datadirs need `nigiri forget` before upgrade so the new `docker-compose.yml` is re-provisioned.
- If a strict client refuses the WS handshake without a sub-protocol header, we can add `--server-protocol electrum` to the `electrum-ws` command. Left off by default since it's a no-op for clients that don't ask for one and could surprise clients that ask for a different value.