### PR TITLE
Update ark-wallet and ark images to v0.9.4

### DIFF
--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -292,7 +292,7 @@ services:
 
   ark-wallet:
     container_name: ark-wallet
-    image: ghcr.io/arkade-os/arkd-wallet:v0.9.3
+    image: ghcr.io/arkade-os/arkd-wallet:v0.9.4
     restart: unless-stopped
     depends_on:
       - bitcoin
@@ -324,7 +324,7 @@ services:
 
   ark:
     container_name: ark
-    image: ghcr.io/arkade-os/arkd:v0.9.3
+    image: ghcr.io/arkade-os/arkd:v0.9.4
     restart: unless-stopped
     depends_on:
       - bitcoin


### PR DESCRIPTION
## Summary
Bumps `ghcr.io/arkade-os/arkd` and `ghcr.io/arkade-os/arkd-wallet` from `v0.9.3` to `v0.9.4`.

Follows the cadence established by #252 (v0.9.1) and earlier bump PRs.

## Test plan
- [x] `go build ./...`
- [x] `docker compose -f cmd/nigiri/resources/docker-compose.yml config --quiet`
- [ ] `nigiri start --ark` — arkd boots, wallet creates/unlocks, faucet flow works on the new images