### PR TITLE
fix nbxplorer startup

### DIFF
--- a/cmd/nigiri/resources/docker-compose.yml
+++ b/cmd/nigiri/resources/docker-compose.yml
@@ -260,6 +260,12 @@ services:
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRES_DB=arkd
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d arkd"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
     volumes:
       - ./volumes/postgres:/var/lib/postgresql/data
 
@@ -268,8 +274,10 @@ services:
     expose:
       - "32838"
     depends_on:
-      - postgres
-      - bitcoin
+      postgres:
+        condition: service_healthy
+      bitcoin:
+        condition: service_started
     image: nicolasdorier/nbxplorer:2.6.0
     environment:
       NBXPLORER_NETWORK: regtest
@@ -300,7 +308,7 @@ services:
     environment:
       ARKD_WALLET_LOG_LEVEL: "5"
       ARKD_WALLET_NBXPLORER_URL: "http://nbxplorer:32838"
-      ARKD_WALLET_NETWORK: "regtest"      
+      ARKD_WALLET_NETWORK: "regtest"
       ARKD_WALLET_SIGNER_KEY: "19422b10efd05403820ff6a3365422be2fc5f07f34a6d1603f7298328f0f80f6"
     volumes:
       - ./volumes/ark/wallet:/app/data


### PR DESCRIPTION
nbxplorer doesn't properly wait for postgres to be ready, so it starts too soon and always fail after a timeout of one minute.

This PR fixes this behaviour.

@Kukks please review